### PR TITLE
Sort available options lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,13 @@ sparkPostTransport(options);
 
 #### Available options
 
-+ `sparkPostApiKey`
-+ `tags`
-+ `metadata`
 + `campaign_id`
 + `content`
++ `metadata`
 + `options`
++ `sparkPostApiKey`
 + `substitution_data`
++ `tags`
 
 ### `sendMail`
 
@@ -87,10 +87,10 @@ transport.sendMail(options, function(err, info) {});
 
 #### Available options
 
-+ `options`
-+ `content`
 + `campaign_id`
-+ `substitution_data`
-+ `recipients`
-+ `tags`
++ `content`
 + `metadata`
++ `options`
++ `recipients`
++ `substitution_data`
++ `tags`


### PR DESCRIPTION
It was hard to quickly visually compare sparkPostTransport and sendMail options lists, since they had mostly same fields but both in random different orders.

Not a biggie but helps a bit.
