### PR TITLE
Implemented the Nodemailer API

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,4 @@
+{
+  "extends": "sparkpost/api"
+}
+

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ transport.sendMail({
   if (err) {
     console.log('Error: ' + err);
   } else {
-    console.log('Success': ' + info);
+    console.log('Success: ' + info);
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,9 @@ var transporter = nodemailer.createTransport(sparkPostTransport(options))
 
 where:
 
-  - **options** defines connection _default_ message properties
+  - **options** defines connection _default_ transmission properties
     - `sparkPostApiKey` - SparkPost [API Key](https://app.sparkpost.com/account/credentials). If not provided, it will use the `SPARKPOST_API_KEY` env var.
     - `campaign_id` - Name of the campaign (optional)
-    - `content` - Content that will be used to construct a message (optional)
     - `metadata` - Transmission level metadata containing key/value pairs (optional)
     - `options` - JSON object in which transmission options are defined (optional)
     - `substitution_data` - Key/value pairs that are provided to the substitution engine (optional)

--- a/README.md
+++ b/README.md
@@ -7,101 +7,60 @@ SparkPost transport for Nodemailer
 
 ## Usage
 
-Install with npm
+### Install
 
 ```
 npm install nodemailer-sparkpost-transport
 ```
 
-Require to your script
+### Create a Nodemailer transport object
 
 ```javascript
 var nodemailer = require('nodemailer');
 var sparkPostTransport = require('nodemailer-sparkpost-transport');
-```
-
-Create a Nodemailer transport object
-
-```javascript
 var transporter = nodemailer.createTransport(sparkPostTransport(options))
 ```
 
-Where
+where:
 
-  - **options** defines connection and message data
+  - **options** defines connection _default_ message properties
     - `sparkPostApiKey` - SparkPost [API Key](https://app.sparkpost.com/account/credentials). If not provided, it will use the `SPARKPOST_API_KEY` env var.
-    - `campaign_id` - Name of the campaign
-    - `content` - Content that will be used to construct a message
-    - `metadata` - Transmission level metadata containing key/value pairs
-    - `options` - JSON object in which transmission options are defined
-    - `substitution_data` - Key/value pairs that are provided to the substitution engine
+    - `campaign_id` - Name of the campaign (optional)
+    - `content` - Content that will be used to construct a message (optional)
+    - `metadata` - Transmission level metadata containing key/value pairs (optional)
+    - `options` - JSON object in which transmission options are defined (optional)
+    - `substitution_data` - Key/value pairs that are provided to the substitution engine (optional)
 
-  For more information, see the [SparkPost API Documentation for Transmissions](https://developers.sparkpost.com/api/#/reference/transmissions)
+  For more information, see the [SparkPost API Documentation for Transmissions](https://developers.sparkpost.com/api/transmissions)
 
-
-
-Send a message
+## Send a message
 
 ```javascript
-transport.sendMail(options, function(err, info) {});
-```
-
-Where
-
-  - **options** defines connection and message data
-    - `recipients` - Inline recipient objects or object containing stored recipient list ID. See [SparkPost API Documentation for Recipient Lists](https://developers.sparkpost.com/api/#/reference/recipient-lists) for more information.
-    - `campaign_id` - Override for option above
-    - `content` - Override for option above
-    - `metadata` - Override for option above
-    - `options` - Override for option above
-    - `substitution_data` - Override for option above
-
-## Example
-
-```javascript
-'use strict';
-
-var nodemailer = require('nodemailer');
-var sparkPostTransport = require('nodemailer-sparkpost-transport');
-
-var transporter = nodemailer.createTransport(sparkPostTransport({
-  "sparkPostApiKey": "<YOUR_API_KEY>",
-  "options": {
-    "open_tracking": true,
-    "click_tracking": true,
-    "transactional": true
-  },
-  "campaign_id": "Nodemailer Default",
-  "metadata": {
-    "some_useful_metadata": "testing_sparkpost"
-  },
-  "substitution_data": {
-    "sender": "YOUR NAME",
-    "fullName": "YOUR NAME",
-    "productName": "The coolest product ever",
-    "sparkpostSupportEmail": "support@sparkpost.com",
-    "sparkpostSupportPhone": "123-456-7890"
-  },
-  "content": {
-    "template_id": "ADD YOUR TEMPLATE ID HERE"
-  }
-}));
-
-
-transporter.sendMail({
-  "recipients": [
-    {
-      "address": {
-        "email": "CHANGE TO YOUR TARGET TEST EMAIL",
-        "name": "CHANGE TO YOUR RECIPIENT NAME"
-      }
-    }
-  ]
+transport.sendMail({
+  from: 'me@here.com',
+  to: 'you@there.com',
+  subject: 'Very important stuff',
+  text: 'Plain text',
+  html: 'Rich taggery'
 }, function(err, info) {
   if (err) {
-    console.error(err);
+    console.log('Error: ' + err);
   } else {
-    console.log(info);
-  }
+    console.log('Success': ' + info);
 });
 ```
+
+[Read more about Nodemailer's `sendMail()` method here](https://github.com/nodemailer/nodemailer#sending-mail).
+
+### Additional Options
+
+The SparkPost Nodemailer transport also supports a few SparkPost-specific `sendMail()` options in both the transport constructor and the 'sendMail()` method.
+
+Note: `sendMail()` options override their constructor counterparts:
+
+  - **options**
+    - `campaign_id` - Overrides for constructor option
+    - `metadata` - Override for constructor option
+    - `options` - Override for constructor option
+    - `substitution_data` - Override for constructor option
+

--- a/examples/sendmail.js
+++ b/examples/sendmail.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var nodemailer = require('nodemailer')
+  , sparkPostTransport = require('nodemailer-sparkpost-transport');
+
+var transporter = nodemailer.createTransport(sparkPostTransport({
+  "sparkPostApiKey": "<YOUR_API_KEY>",
+  "options": {
+    "open_tracking": true,
+    "click_tracking": true,
+    "transactional": true
+  },
+  "campaign_id": "Nodemailer Demo",
+}));
+
+transporter.sendMail({
+  from: 'me@example.com',
+  to: 'you@example.net',
+  subject: 'Nodemailer + SparkPost = Sheer Awe',
+  text: 'Plain text email content',
+  html: '<p>Richly <strong>marked up</strong> email content</p>'
+}, function(err, info) {
+  if (err) {
+    console.error(err);
+  } else {
+    console.log(info);
+  }
+});
+

--- a/examples/sendmail.js
+++ b/examples/sendmail.js
@@ -1,17 +1,17 @@
 'use strict';
 
+/* eslint-disable no-console */
 var nodemailer = require('nodemailer')
-  , sparkPostTransport = require('nodemailer-sparkpost-transport');
-
-var transporter = nodemailer.createTransport(sparkPostTransport({
-  "sparkPostApiKey": "<YOUR_API_KEY>",
-  "options": {
-    "open_tracking": true,
-    "click_tracking": true,
-    "transactional": true
-  },
-  "campaign_id": "Nodemailer Demo",
-}));
+  , sparkPostTransport = require('nodemailer-sparkpost-transport')
+  , transporter = nodemailer.createTransport(sparkPostTransport({
+    'sparkPostApiKey': '<YOUR_API_KEY>',
+    'options': {
+      'open_tracking': true,
+      'click_tracking': true,
+      'transactional': true
+    },
+    'campaign_id': 'Nodemailer Demo'
+  }));
 
 transporter.sendMail({
   from: 'me@example.com',

--- a/lib/sparkPostTransport.js
+++ b/lib/sparkPostTransport.js
@@ -80,9 +80,7 @@ SparkPostTransport.prototype.send = function send(message, callback) {
   }
 
   if (data.raw) {
-    if (data.raw) {
-      resolveme.raw = 'email_rfc822';
-    }
+    resolveme.raw = 'email_rfc822';
   } else {
     populateInlineStdFields(message, resolveme, request);
   }

--- a/lib/sparkPostTransport.js
+++ b/lib/sparkPostTransport.js
@@ -1,11 +1,13 @@
 'use strict';
 
 // Dependencies
-var pkg = require('../package');
-var SparkPost = require('sparkpost');
+var pkg = require('../package')
+  , SparkPost = require('sparkpost');
 
 // Constructor
-var SparkPostTransport = function SparkPostTransport(options) {
+function SparkPostTransport(options) {
+  var opt;
+
   // Set required properties
   this.name = 'SparkPost';
   this.version = pkg.version;
@@ -13,89 +15,99 @@ var SparkPostTransport = function SparkPostTransport(options) {
 
   // Set the SparkPost API Key (must have appropriate Transmission resource permissions)
   this.sparkPostApiKey = process.env.SPARKPOST_API_KEY || options.sparkPostApiKey;
-  this.sparkPostEmailClient = new SparkPost( this.sparkPostApiKey );
+  this.sparkPostEmailClient = new SparkPost(this.sparkPostApiKey);
 
   // Set any options which are valid
-  for( var opt in options ) {
-    this[opt] = (options.hasOwnProperty( opt )) ? options[opt] : undefined;
+  for(opt in options) {
+    this[opt] = (options.hasOwnProperty(opt)) ? options[opt] : undefined;
   }
 
   return this;
-};
+}
 
-SparkPostTransport.prototype.send = function send(message, callback) {
-  var self = this
-    , data = message.data
-    , request = {
-      content: {}
-    }
-    , customFields = ['tags', 'campaign_id', 'metadata', 'substitution_data', 'options', 'content', 'recipients'];
+function populateCustomFields(message, defaults, request) {
+  var data = message.data
+    , customFields = ['campaign_id', 'metadata', 'substitution_data', 'options', 'content', 'recipients'];
 
   // Apply default SP-centric options and override if provided in mail object
   customFields.forEach(function(fld) {
     if (data.hasOwnProperty(fld)) {
       request[fld] = data[fld];
-    } else if (self.hasOwnProperty(fld)) {
-      request[fld] = self[fld];
+    } else if (defaults.hasOwnProperty(fld)) {
+      request[fld] = defaults[fld];
     }
   });
+}
+
+function populateInlineStdFields(message, resolveme, request) {
+  var data = message.data;
+
+  if (data.from) {
+    request.content.from = data.from;
+  }
+
+  // cc
+  // bcc
+
+  if (data.subject) {
+    request.content.subject = data.subject;
+  }
+
+  if (data.html) {
+    resolveme.html = 'html';
+  }
+
+  if (data.text) {
+    resolveme.text = 'text';
+  }
+
+  // attachments
+  // headers
+}
+
+SparkPostTransport.prototype.send = function send(message, callback) {
+  var data = message.data
+    , request = {
+      content: {}
+    }
+    , resolveme = {};
 
   // Conventional nodemailer fields override SparkPost-specific ones and defaults
+  populateCustomFields(message, this, request);
 
   if (data.to) {
     request.recipients = emailList(data.to) || [];
   }
 
-  var resolveme = [];
   if (data.raw) {
-    resolveme.push(['raw', 'email_rfc822']);
+    if (data.raw) {
+      resolveme.raw = 'email_rfc822';
+    }
   } else {
-
-    if (data.from) {
-      request.content.from = data.from;
-    }
-
-    // cc
-    // bcc
-
-    if (data.subject) {
-      request.content.subject = data.subject;
-    }
-
-    if (data.html) {
-      resolveme.push('html');
-    }
-
-    if (data.text) {
-      resolveme.push('text');
-    }
-
-    // attachments
-    // headers
+    populateInlineStdFields(message, resolveme, request);
   }
 
   this.resolveAndSend(message, resolveme, request, callback);
 };
 
-SparkPostTransport.prototype.resolveAndSend = function(mail, keys, request, callback) {
+SparkPostTransport.prototype.resolveAndSend = function(mail, toresolve, request, callback) {
   var self = this
+    , keys = Object.keys(toresolve)
     , srckey
-    , dstkey; 
+    , dstkey;
 
   if (keys.length === 0) {
     return this.sendWithSparkPost(request, callback);
   }
 
-  if (typeof keys[0] === 'string') {
-    srckey = dstkey = keys[0];
-  } else {
-    srckey = keys[0][0];
-    dstkey = keys[0][1];
-  }
+  srckey = keys[0];
+  dstkey = toresolve[keys[0]];
+
+  delete toresolve[srckey];
 
   this.loadContent(mail, srckey, function(err, content) {
     request.content[dstkey] = content;
-    self.resolveAndSend(mail, keys.slice(1), request, callback);
+    self.resolveAndSend(mail, toresolve, request, callback);
   });
 };
 
@@ -115,7 +127,7 @@ SparkPostTransport.prototype.loadContent = function(mail, key, callback) {
 };
 
 SparkPostTransport.prototype.sendWithSparkPost = function(transBody, callback) {
-  this.sparkPostEmailClient.transmissions.send({transmissionBody: transBody}, function( err, res ) {
+  this.sparkPostEmailClient.transmissions.send({transmissionBody: transBody}, function(err, res) {
     if (err) {
       return callback(err);
     }
@@ -150,3 +162,4 @@ function emailList(strOrLst) {
 module.exports = function(options) {
   return new SparkPostTransport(options);
 };
+

--- a/lib/sparkPostTransport.js
+++ b/lib/sparkPostTransport.js
@@ -23,35 +23,129 @@ var SparkPostTransport = function SparkPostTransport(options) {
   return this;
 };
 
-SparkPostTransport.prototype.send = function send(payload, callback) {
-  var email = {
-    transmissionBody: {}
-  };
+SparkPostTransport.prototype.send = function send(message, callback) {
+  var self = this
+    , data = message.data
+    , request = {
+      content: {}
+    }
+    , customFields = ['tags', 'campaign_id', 'metadata', 'substitution_data', 'options', 'content', 'recipients'];
 
-  // Apply default options and override if provided in mail object
-  email.transmissionBody.tags              = (payload.data.tags) ? payload.data.tags : this.tags;
-  email.transmissionBody.campaign_id       = (payload.data.campaign_id) ? payload.data.campaign_id : this.campaign_id;
-  email.transmissionBody.metadata          = (payload.data.metadata) ? payload.data.metadata : this.metadata;
-  email.transmissionBody.substitution_data = (payload.data.substitution_data) ? payload.data.substitution_data : this.substitution_data;
-  email.transmissionBody.options           = (payload.data.options) ? payload.data.options : this.options;
-  email.transmissionBody.content           = (payload.data.content) ? payload.data.content : this.content;
-  email.transmissionBody.recipients        = (payload.data.recipients) ? payload.data.recipients : this.recipients;
-
-  // Send the transmission using Sparkpost
-  this.sparkPostEmailClient.transmissions.send(email, function( err, res ) {
-    if( err ) {
-      return callback( err );
-    } else {
-      // Example successful Sparkpost transmission response:
-      // { "results": { "total_rejected_recipients": 0, "total_accepted_recipients": 1, "id": "66123596945797072" } }
-      return callback( null, {
-        messageId: res.body.results.id,
-        accepted: res.body.results.total_accepted_recipients,
-        rejected: res.body.results.total_rejected_recipients
-      });
+  // Apply default SP-centric options and override if provided in mail object
+  customFields.forEach(function(fld) {
+    if (data.hasOwnProperty(fld)) {
+      request[fld] = data[fld];
+    } else if (self.hasOwnProperty(fld)) {
+      request[fld] = self[fld];
     }
   });
+
+  // Conventional nodemailer fields override SparkPost-specific ones and defaults
+
+  if (data.to) {
+    request.recipients = emailList(data.to) || [];
+  }
+
+  var resolveme = [];
+  if (data.raw) {
+    resolveme.push(['raw', 'email_rfc822']);
+  } else {
+
+    if (data.from) {
+      request.content.from = data.from;
+    }
+
+    // cc
+    // bcc
+
+    if (data.subject) {
+      request.content.subject = data.subject;
+    }
+
+    if (data.html) {
+      resolveme.push('html');
+    }
+
+    if (data.text) {
+      resolveme.push('text');
+    }
+
+    // attachments
+    // headers
+  }
+
+  this.resolveAndSend(message, resolveme, request, callback);
 };
+
+SparkPostTransport.prototype.resolveAndSend = function(mail, keys, request, callback) {
+  var self = this
+    , srckey
+    , dstkey; 
+
+  if (keys.length === 0) {
+    return this.sendWithSparkPost(request, callback);
+  }
+
+  if (typeof keys[0] === 'string') {
+    srckey = dstkey = keys[0];
+  } else {
+    srckey = keys[0][0];
+    dstkey = keys[0][1];
+  }
+
+  this.loadContent(mail, srckey, function(err, content) {
+    request.content[dstkey] = content;
+    self.resolveAndSend(mail, keys.slice(1), request, callback);
+  });
+};
+
+SparkPostTransport.prototype.loadContent = function(mail, key, callback) {
+  var content = mail.data[key];
+  if (typeof content === 'string') {
+    return process.nextTick(function() {
+      callback(null, content);
+    });
+  }
+  mail.resolveContent(mail.data, key, function(err, res) {
+    if (err) {
+      return callback(err);
+    }
+    callback(null, res.toString());
+  });
+};
+
+SparkPostTransport.prototype.sendWithSparkPost = function(transBody, callback) {
+  this.sparkPostEmailClient.transmissions.send({transmissionBody: transBody}, function( err, res ) {
+    if (err) {
+      return callback(err);
+    }
+    // Example successful Sparkpost transmission response:
+    // { "results": { "total_rejected_recipients": 0, "total_accepted_recipients": 1, "id": "66123596945797072" } }
+    return callback(null, {
+      messageId: res.body.results.id,
+      accepted: res.body.results.total_accepted_recipients,
+      rejected: res.body.results.total_rejected_recipients
+    });
+  });
+};
+
+function emailList(strOrLst) {
+  var lst = strOrLst;
+  if (typeof strOrLst === 'string') {
+    lst = strOrLst.split(',');
+  }
+
+  return lst.map(function(addr) {
+    if (typeof addr === 'string') {
+      return {address: addr};
+    }
+    return {
+      address: {
+        name: addr.name,
+        email: addr.address
+      }};
+  });
+}
 
 module.exports = function(options) {
   return new SparkPostTransport(options);

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "mocha": "^2.4.5",
+    "nodemailer": "^2.5.0",
     "sinon": "^1.17.4",
     "with-package": "^0.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^3.1.1",
+    "eslint": "=3.0.0",
     "eslint-config-sparkpost": "^1.0.1",
     "mocha": "^2.4.5",
     "nodemailer": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "SparkPost transport for Nodemailer",
   "main": "lib/sparkPostTransport.js",
   "scripts": {
+    "pretest": "eslint examples lib test *.js",
     "test": "mocha",
     "release": "with-package git commit -am pkg.version && with-package git tag pkg.version && git push upstream && npm publish && git push --tags upstream"
   },
@@ -26,6 +27,8 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "eslint": "^3.1.1",
+    "eslint-config-sparkpost": "^1.0.1",
     "mocha": "^2.4.5",
     "nodemailer": "^2.5.0",
     "sinon": "^1.17.4",

--- a/test/sparkpostTransport.js
+++ b/test/sparkpostTransport.js
@@ -1,104 +1,101 @@
-"use strict";
+'use strict';
 
-var sinon = require("sinon");
-var expect = require("chai").expect;
+var sinon = require('sinon')
+  , expect = require('chai').expect
+  , nodemailer = require('nodemailer')
+  , sparkPostTransport = require('../lib/sparkPostTransport.js')
+  , pkg = require('../package.json');
 
-var nodemailer = require('nodemailer');
-var sparkPostTransport = require("../lib/sparkPostTransport.js");
+describe('SparkPost Transport', function() {
+  var transport = sparkPostTransport({sparkPostApiKey: '12345678901234567890'});
 
-var pkg = require("../package.json");
-
-describe("SparkPost Transport", function() {
-  var transport = sparkPostTransport({sparkPostApiKey: "12345678901234567890"});
-
-  it("should have a name and version property", function(done) {
-    expect(transport).to.have.property("name", "SparkPost");
-    expect(transport).to.have.property("version", pkg.version);
+  it('should have a name and version property', function(done) {
+    expect(transport).to.have.property('name', 'SparkPost');
+    expect(transport).to.have.property('version', pkg.version);
     done();
   });
 
-  it("should expose a send method", function(done) {
+  it('should expose a send method', function(done) {
     expect(transport.send).to.exist;
-    expect(transport.send).to.be.a("function");
+    expect(transport.send).to.be.a('function');
     done();
   });
 
-  it("should be able to set options", function(done) {
+  it('should be able to set options', function(done) {
     var transport = sparkPostTransport({
-      sparkPostApiKey: "12345678901234567890",
-      campaign_id: "sample_campaign",
-      tags: ["new-account-notification"],
-      metadata: {"source": "event"},
-      substitution_data: {"salutatory": "Welcome to SparkPost!"},
-      options: {"click_tracking": true, "open_tracking": true},
-      content: {"template_id": "newAccountNotification"},
-      recipients: [{"email": "john.doe@example.com", "name": "John Doe"}]
+      sparkPostApiKey: '12345678901234567890',
+      campaign_id: 'sample_campaign',
+      tags: ['new-account-notification'],
+      metadata: {'source': 'event'},
+      substitution_data: {'salutatory': 'Welcome to SparkPost!'},
+      options: {'click_tracking': true, 'open_tracking': true},
+      content: {'template_id': 'newAccountNotification'},
+      recipients: [{'email': 'john.doe@example.com', 'name': 'John Doe'}]
     });
 
-    expect(transport.campaign_id).to.equal("sample_campaign");
-    expect(transport.tags).to.deep.equal(["new-account-notification"]);
-    expect(transport.metadata).to.deep.equal({"source": "event"});
-    expect(transport.substitution_data).to.deep.equal({"salutatory": "Welcome to SparkPost!"});
-    expect(transport.options).to.deep.equal({"click_tracking": true, "open_tracking": true});
-    expect(transport.content).to.deep.equal({"template_id": "newAccountNotification"});
-    expect(transport.recipients).to.deep.equal([{"email": "john.doe@example.com", "name": "John Doe"}]);
+    expect(transport.campaign_id).to.equal('sample_campaign');
+    expect(transport.tags).to.deep.equal(['new-account-notification']);
+    expect(transport.metadata).to.deep.equal({'source': 'event'});
+    expect(transport.substitution_data).to.deep.equal({'salutatory': 'Welcome to SparkPost!'});
+    expect(transport.options).to.deep.equal({'click_tracking': true, 'open_tracking': true});
+    expect(transport.content).to.deep.equal({'template_id': 'newAccountNotification'});
+    expect(transport.recipients).to.deep.equal([{'email': 'john.doe@example.com', 'name': 'John Doe'}]);
 
     done();
   });
 
 });
 
-describe("Send Method", function() {
+describe('Send Method', function() {
 
   describe('SP-centric mail structure', function() {
-    it("should be able to overload options at the transmission", function(done) {
+    it('should be able to overload options at the transmission', function(done) {
       // Create the default transport
       var transport = sparkPostTransport({
-        sparkPostApiKey: "12345678901234567890",
-        campaign_id: "sample_campaign",
-        tags: ["new-account-notification"],
-        metadata: {"source": "event"},
-        substitution_data: {"salutatory": "Welcome to SparkPost!"},
-        options: {"click_tracking": true, "open_tracking": true},
-        content: {"template_id": "newAccountNotification"},
-        recipients: [{"email": "john.doe@example.com", "name": "John Doe"}]
-      });
+          sparkPostApiKey: '12345678901234567890',
+          campaign_id: 'sample_campaign',
+          tags: ['new-account-notification'],
+          metadata: {'source': 'event'},
+          substitution_data: {'salutatory': 'Welcome to SparkPost!'},
+          options: {'click_tracking': true, 'open_tracking': true},
+          content: {'template_id': 'newAccountNotification'},
+          recipients: [{'email': 'john.doe@example.com', 'name': 'John Doe'}]
+        })
+        // Create the modified options for use with the above stub test
+        , overloadedTransmission = {
+          campaign_id: 'another_sample_campaign',
+          tags: ['alternative-tag'],
+          metadata: {'changedKey': 'value'},
+          substitution_data: {'salutatory': 'And now...for something completely different'},
+          options: {'click_tracking': false, 'open_tracking': false, 'transactional': true},
+          recipients: [{
+            list_id: 'myStoredRecipientTestList'
+          }],
+          content: {
+            template_id: 'someOtherTemplate'
+          }
+        };
 
       // Stub the send method of the SDK out
-      sinon.stub(transport, "send", function(data, resolve) {
+      sinon.stub(transport, 'send', function(data, resolve) {
         // Grab the transmissionBody from the send() payload for assertions
-        expect(data.campaign_id).to.equal("another_sample_campaign");
-        expect(data.tags).to.deep.equal(["alternative-tag"]);
-        expect(data.metadata).to.deep.equal({"changedKey": "value"});
-        expect(data.substitution_data).to.deep.equal({"salutatory": "And now...for something completely different"});
-        expect(data.options).to.deep.equal({"click_tracking": false, "open_tracking": false, "transactional": true});
-        expect(data.content).to.deep.equal({"template_id": "someOtherTemplate"});
-        expect(data.recipients).to.deep.equal([{"list_id": "myStoredRecipientTestList"}]);
+        expect(data.campaign_id).to.equal('another_sample_campaign');
+        expect(data.tags).to.deep.equal(['alternative-tag']);
+        expect(data.metadata).to.deep.equal({'changedKey': 'value'});
+        expect(data.substitution_data).to.deep.equal({'salutatory': 'And now...for something completely different'});
+        expect(data.options).to.deep.equal({'click_tracking': false, 'open_tracking': false, 'transactional': true});
+        expect(data.content).to.deep.equal({'template_id': 'someOtherTemplate'});
+        expect(data.recipients).to.deep.equal([{'list_id': 'myStoredRecipientTestList'}]);
 
         // Resolve the stub's spy
         resolve({
           results: {
             total_rejected_recipients: 0,
             total_accepted_recipients: 1,
-            id: "66123596945797072"
+            id: '66123596945797072'
           }
         });
       });
-
-      // Create the modified options for use with the above stub test
-      var overloadedTransmission = {
-        campaign_id: "another_sample_campaign",
-        tags: ["alternative-tag"],
-        metadata: {"changedKey": "value"},
-        substitution_data: {"salutatory": "And now...for something completely different"},
-        options: {"click_tracking": false, "open_tracking": false, "transactional": true},
-        recipients: [{
-          list_id: "myStoredRecipientTestList"
-        }],
-        content: {
-          template_id: "someOtherTemplate"
-        }
-      };
 
       // Call the stub from above
       transport.send(overloadedTransmission, function(data) {
@@ -133,7 +130,7 @@ describe("Send Method", function() {
 
     beforeEach(function() {
       sptrans = sparkPostTransport({
-        sparkPostApiKey: "12345678901234567890"
+        sparkPostApiKey: '12345678901234567890'
       });
 
       transport = nodemailer.createTransport(sptrans);
@@ -153,13 +150,13 @@ describe("Send Method", function() {
         results: {
           total_rejected_recipients: 0,
           total_accepted_recipients: 1,
-          id: "66123596945797072"
+          id: '66123596945797072'
         }
       });
     });
 
     it('should accept basic nodemailer mail content fields', function(done) {
-      transport.sendMail(mail, function(result) {
+      transport.sendMail(mail, function() {
         var req = sptrans.sparkPostEmailClient.transmissions.send.firstCall.args[0]
           , transBody = req.transmissionBody;
 
@@ -183,7 +180,7 @@ describe("Send Method", function() {
       delete mail.html;
       delete mail.from;
       mail.raw = 'rawmsg';
-      transport.sendMail(mail, function(result) {
+      transport.sendMail(mail, function() {
         var req = sptrans.sparkPostEmailClient.transmissions.send.firstCall.args[0]
           , transBody = req.transmissionBody;
 
@@ -200,14 +197,14 @@ describe("Send Method", function() {
 
     it('should accept to as an array', function(done) {
       mail.to = [rcp1, rcp2];
-      transport.sendMail(mail, function(result) {
+      transport.sendMail(mail, function() {
         checkTo(done);
       });
     });
 
     it('should accept to as a string', function(done) {
       mail.to = [rcp1, rcp2].join(',');
-      transport.sendMail(mail, function(result) {
+      transport.sendMail(mail, function() {
         checkTo(done);
       });
     });

--- a/test/sparkpostTransport.js
+++ b/test/sparkpostTransport.js
@@ -3,6 +3,7 @@
 var sinon = require("sinon");
 var expect = require("chai").expect;
 
+var nodemailer = require('nodemailer');
 var sparkPostTransport = require("../lib/sparkPostTransport.js");
 
 var pkg = require("../package.json");
@@ -49,32 +50,106 @@ describe("SparkPost Transport", function() {
 
 describe("Send Method", function() {
 
-  it("should be able to overload options at the transmission", function(done) {
-    // Create the default transport
-    var transport = sparkPostTransport({
-      sparkPostApiKey: "12345678901234567890",
-      campaign_id: "sample_campaign",
-      tags: ["new-account-notification"],
-      metadata: {"source": "event"},
-      substitution_data: {"salutatory": "Welcome to SparkPost!"},
-      options: {"click_tracking": true, "open_tracking": true},
-      content: {"template_id": "newAccountNotification"},
-      recipients: [{"email": "john.doe@example.com", "name": "John Doe"}]
+  describe('SP-centric mail structure', function() {
+    it("should be able to overload options at the transmission", function(done) {
+      // Create the default transport
+      var transport = sparkPostTransport({
+        sparkPostApiKey: "12345678901234567890",
+        campaign_id: "sample_campaign",
+        tags: ["new-account-notification"],
+        metadata: {"source": "event"},
+        substitution_data: {"salutatory": "Welcome to SparkPost!"},
+        options: {"click_tracking": true, "open_tracking": true},
+        content: {"template_id": "newAccountNotification"},
+        recipients: [{"email": "john.doe@example.com", "name": "John Doe"}]
+      });
+
+      // Stub the send method of the SDK out
+      sinon.stub(transport, "send", function(data, resolve) {
+        // Grab the transmissionBody from the send() payload for assertions
+        expect(data.campaign_id).to.equal("another_sample_campaign");
+        expect(data.tags).to.deep.equal(["alternative-tag"]);
+        expect(data.metadata).to.deep.equal({"changedKey": "value"});
+        expect(data.substitution_data).to.deep.equal({"salutatory": "And now...for something completely different"});
+        expect(data.options).to.deep.equal({"click_tracking": false, "open_tracking": false, "transactional": true});
+        expect(data.content).to.deep.equal({"template_id": "someOtherTemplate"});
+        expect(data.recipients).to.deep.equal([{"list_id": "myStoredRecipientTestList"}]);
+
+        // Resolve the stub's spy
+        resolve({
+          results: {
+            total_rejected_recipients: 0,
+            total_accepted_recipients: 1,
+            id: "66123596945797072"
+          }
+        });
+      });
+
+      // Create the modified options for use with the above stub test
+      var overloadedTransmission = {
+        campaign_id: "another_sample_campaign",
+        tags: ["alternative-tag"],
+        metadata: {"changedKey": "value"},
+        substitution_data: {"salutatory": "And now...for something completely different"},
+        options: {"click_tracking": false, "open_tracking": false, "transactional": true},
+        recipients: [{
+          list_id: "myStoredRecipientTestList"
+        }],
+        content: {
+          template_id: "someOtherTemplate"
+        }
+      };
+
+      // Call the stub from above
+      transport.send(overloadedTransmission, function(data) {
+        expect(data.results.id).to.exist;
+        expect(data.results.total_rejected_recipients).to.exist;
+        expect(data.results.total_accepted_recipients).to.exist;
+        done();
+      });
+      // Return the original method to its proper state
+      transport.send.restore();
     });
+  });
 
-    // Stub the send method of the SDK out
-    sinon.stub(transport, "send", function(data, resolve) {
-      // Grab the transmissionBody from the send() payload for assertions
-      expect(data.campaign_id).to.equal("another_sample_campaign");
-      expect(data.tags).to.deep.equal(["alternative-tag"]);
-      expect(data.metadata).to.deep.equal({"changedKey": "value"});
-      expect(data.substitution_data).to.deep.equal({"salutatory": "And now...for something completely different"});
-      expect(data.options).to.deep.equal({"click_tracking": false, "open_tracking": false, "transactional": true});
-      expect(data.content).to.deep.equal({"template_id": "someOtherTemplate"});
-      expect(data.recipients).to.deep.equal([{"list_id": "myStoredRecipientTestList"}]);
+  describe('conventional nodemailer mail structure', function() {
+    var sptrans
+      , transport
+      , mail
+      , rcp1
+      , rcp2;
 
-      // Resolve the stub's spy
-      resolve({
+    function checkTo(done) {
+      var req = sptrans.sparkPostEmailClient.transmissions.send.firstCall.args[0]
+        , transBody = req.transmissionBody;
+
+      expect(req).to.have.keys('transmissionBody');
+      expect(transBody).to.have.keys(['recipients', 'content']);
+      expect(transBody.recipients).to.have.length(2);
+      expect(transBody.recipients[0]).to.deep.equal({ address: rcp1 });
+      expect(transBody.recipients[1]).to.deep.equal({ address: rcp2 });
+      done();
+    }
+
+    beforeEach(function() {
+      sptrans = sparkPostTransport({
+        sparkPostApiKey: "12345678901234567890"
+      });
+
+      transport = nodemailer.createTransport(sptrans);
+
+      rcp1 = 'Mrs. Asoni <a@a.com>';
+      rcp2 = 'b@b.com';
+
+      mail = {
+        from: 'roberto@from.example.com',
+        to: 'kingcnut@to.example.com',
+        subject: 'Modern Kinging',
+        text: 'Edicts and surfeits...',
+        html: '<p>Edicts and surfeits...</p>'
+      };
+
+      sptrans.sparkPostEmailClient.transmissions.send = sinon.stub().yields({
         results: {
           total_rejected_recipients: 0,
           total_accepted_recipients: 1,
@@ -83,29 +158,59 @@ describe("Send Method", function() {
       });
     });
 
-    // Create the modified options for use with the above stub test
-    var overloadedTransmission = {
-      campaign_id: "another_sample_campaign",
-      tags: ["alternative-tag"],
-      metadata: {"changedKey": "value"},
-      substitution_data: {"salutatory": "And now...for something completely different"},
-      options: {"click_tracking": false, "open_tracking": false, "transactional": true},
-      recipients: [{
-        list_id: "myStoredRecipientTestList"
-      }],
-      content: {
-        template_id: "someOtherTemplate"
-      }
-    };
+    it('should accept basic nodemailer mail content fields', function(done) {
+      transport.sendMail(mail, function(result) {
+        var req = sptrans.sparkPostEmailClient.transmissions.send.firstCall.args[0]
+          , transBody = req.transmissionBody;
 
-    // Call the stub from above
-    transport.send(overloadedTransmission, function(data) {
-      expect(data.results.id).to.exist;
-      expect(data.results.total_rejected_recipients).to.exist;
-      expect(data.results.total_accepted_recipients).to.exist;
-      done();
+        expect(req).to.have.keys('transmissionBody');
+        expect(transBody).to.have.keys(['recipients', 'content']);
+        expect(transBody.content.html).to.equal(mail.html);
+        expect(transBody.content.text).to.equal(mail.text);
+        expect(transBody.content.subject).to.equal(mail.subject);
+        expect(transBody.content.from).to.equal(mail.from);
+        expect(transBody.recipients).to.have.length(1);
+        expect(transBody.recipients[0]).to.have.keys('address');
+        expect(transBody.recipients[0].address).to.be.a('string');
+        expect(transBody.recipients[0].address).to.equal(mail.to);
+        done();
+      });
     });
-    // Return the original method to its proper state
-    transport.send.restore();
+
+    it('should accept raw mail structure', function(done) {
+      delete mail.subject;
+      delete mail.text;
+      delete mail.html;
+      delete mail.from;
+      mail.raw = 'rawmsg';
+      transport.sendMail(mail, function(result) {
+        var req = sptrans.sparkPostEmailClient.transmissions.send.firstCall.args[0]
+          , transBody = req.transmissionBody;
+
+        expect(req).to.have.keys('transmissionBody');
+        expect(transBody).to.have.keys(['recipients', 'content']);
+        expect(transBody.content).to.have.keys('email_rfc822');
+        expect(transBody.recipients).to.have.length(1);
+        expect(transBody.recipients[0]).to.have.keys('address');
+        expect(transBody.recipients[0].address).to.be.a('string');
+        expect(transBody.recipients[0].address).to.equal(mail.to);
+        done();
+      });
+    });
+
+    it('should accept to as an array', function(done) {
+      mail.to = [rcp1, rcp2];
+      transport.sendMail(mail, function(result) {
+        checkTo(done);
+      });
+    });
+
+    it('should accept to as a string', function(done) {
+      mail.to = [rcp1, rcp2].join(',');
+      transport.sendMail(mail, function(result) {
+        checkTo(done);
+      });
+    });
   });
 });
+


### PR DESCRIPTION
- Addressed issue #6 - we now support the Nodemailer `sendMail()` spec without breaking existing code which uses the old SP-centric `options` structure.
- Reworked the README to discourage use of the non-API compliant version
- Added a simple example
